### PR TITLE
Fixed bug where choices with conditions didn't show up at first state load

### DIFF
--- a/agf_parser/agf_parser.py
+++ b/agf_parser/agf_parser.py
@@ -29,11 +29,12 @@ class adventureGame:
         Method must be called when starting a game
         """
         self.title = self.data['title']
+        self.states = self.data['gamevars']
         self.pos = self.data['start_state']
         start_node = self.data['states'][self.pos]
         self.pruneChoices(start_node)
         self.processText(start_node)
-        self.states = self.data['gamevars']
+
 
     def choose(self, c):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
         name         = "agf_parser",
-        version      = "0.0.2",
+        version      = "0.0.3",
         author       = "Sergey Ivanov",
         author_email = "powah.serge@gmail.com",
         description  = "Parses .agf files and makes a game object",


### PR DESCRIPTION
Bug was caused by the pruneChoices function being called before the gamevars were loaded so the start node would not display options with conditions because there were no variables loaded to check against.